### PR TITLE
PR 3: Pass vector arguments by const reference

### DIFF
--- a/include/CHSpline/CHSpline.h
+++ b/include/CHSpline/CHSpline.h
@@ -35,8 +35,8 @@ class Spline
   /**
      \brief Initalise spline coefficients
   */
-  bool initSpline(std::vector<double> ti, std::vector<double> pi,
-                  std::vector<double> vi);
+  bool initSpline(const std::vector<double>& ti, const std::vector<double>& pi,
+                  const std::vector<double>& vi);
 
   /**
      \brief Derivatives calculation using Catmull-Rom Spline construction for
@@ -52,7 +52,7 @@ class Spline
   /**
      \brief Derivatives set to vector values
   */
-  bool initDerivatives(std::vector<double> vi);
+  bool initDerivatives(const std::vector<double>& vi);
 
   /**
      \brief Add a node
@@ -67,9 +67,9 @@ class Spline
   /**
      \brief Evaluate spline for a vector of values
   */
-  bool evalVectorSpline(std::vector<double> t,
+  bool evalVectorSpline(const std::vector<double>& t,
                         std::vector<double>& output) const;
-  std::vector<double> evalVectorSpline(std::vector<double> t) const;
+  std::vector<double> evalVectorSpline(const std::vector<double>& t) const;
 
   /**
      \brief Accessors

--- a/src/CHSpline.cpp
+++ b/src/CHSpline.cpp
@@ -57,8 +57,8 @@ bool Spline::initSpline(double ti0, double ti1, double pi0, double pi1,
   return true;
 }
 
-bool Spline::initSpline(std::vector<double> ti, std::vector<double> pi,
-                        std::vector<double> vi)
+bool Spline::initSpline(const std::vector<double>& ti, const std::vector<double>& pi,
+                        const std::vector<double>& vi)
 {
   // check vector sizes
   if ((ti.size() < 2) || (pi.size() < 2) || (vi.size() < 2))
@@ -159,7 +159,7 @@ bool Spline::initDerivativezero()
   return false;
 }
 
-bool Spline::initDerivatives(std::vector<double> vi)
+bool Spline::initDerivatives(const std::vector<double>& vi)
 {
   if (vi.size() == t_.size())
   {
@@ -214,7 +214,7 @@ double Spline::evalSpline(double te) const
          h4 * v_[noSpline + 1] * (t_[noSpline + 1] - t_[noSpline]);
 }
 
-bool Spline::evalVectorSpline(std::vector<double> t,
+bool Spline::evalVectorSpline(const std::vector<double>& t,
                               std::vector<double>& output) const
 {
   output.clear();
@@ -225,7 +225,7 @@ bool Spline::evalVectorSpline(std::vector<double> t,
   return true;
 }
 
-std::vector<double> Spline::evalVectorSpline(std::vector<double> t) const
+std::vector<double> Spline::evalVectorSpline(const std::vector<double>& t) const
 {
   std::vector<double> output;
   for (std::vector<double>::size_type i = 0; i < t.size(); i++)


### PR DESCRIPTION
Addresses Issue 4: updates Spline's initSpline, initDerivatives, and evalVectorSpline signatures and implementations to pass std::vector by const reference. This avoids making unnecessary copies of double vectors, improving performance.