### PR TITLE
PR 4: Introduce CHSpline namespace

### DIFF
--- a/include/CHSpline/CHSpline.h
+++ b/include/CHSpline/CHSpline.h
@@ -5,6 +5,8 @@
 #include <deque>
 #include <cmath>
 
+namespace CHSpline
+{
 class Spline
 {
  public:
@@ -90,5 +92,6 @@ class Spline
  private:
   std::vector<double> t_, p_, v_;
 };
+} // namespace CHSpline
 
 #endif

--- a/src/CHSpline.cpp
+++ b/src/CHSpline.cpp
@@ -15,6 +15,8 @@
 #include <algorithm>
 #include "CHSpline/CHSpline.h"
 
+namespace CHSpline
+{
 Spline::Spline()
 {
   t_.push_back(0.0);
@@ -234,3 +236,4 @@ std::vector<double> Spline::evalVectorSpline(const std::vector<double>& t) const
   }
   return output;
 }
+} // namespace CHSpline

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,7 @@ int main(int argc, char* argv[])
     printf("As :  %s 0.0 5.0 -1.0 5.0 -1.0 0.0 100 (as here)\n", argv[0]);
   }
 
-  Spline Splines;
+  CHSpline::Spline Splines;
   double t0 = 0.0, t1 = 5.0, p0 = -1.0, p1 = 5.0, v0 = -1.0, v1 = 0.0;
   int Np = 100;
 

--- a/test/test_CHSpline.cpp
+++ b/test/test_CHSpline.cpp
@@ -8,6 +8,8 @@
 #include <vector>
 #include "CHSpline/CHSpline.h"
 
+using CHSpline::Spline;
+
 BOOST_AUTO_TEST_SUITE(TestsCHSpline)
 
 class TestDerived : public Spline


### PR DESCRIPTION
Addresses Issues 5 and 6: wraps the entire Spline library inside a clean CHSpline namespace to prevent global namespace pollution and class name collisions. Updates src/main.cpp and test/test_CHSpline.cpp to use the CHSpline::Spline class.