### PR TITLE
PR 5: Remove user-declared empty destructor

### DIFF
--- a/include/CHSpline/CHSpline.h
+++ b/include/CHSpline/CHSpline.h
@@ -23,10 +23,7 @@ class Spline
   Spline(double ti0, double ti1, double pi0, double pi1, double vi0,
          double vi1);
 
-  /**
-     \brief Destructor
-  */
-  ~Spline();
+
 
   /**
      \brief Initalise spline coefficients for two knot

--- a/src/CHSpline.cpp
+++ b/src/CHSpline.cpp
@@ -38,9 +38,6 @@ Spline::Spline(double ti0, double ti1, double pi0, double pi1, double vi0,
   v_.push_back(vi1);
 }
 
-Spline::~Spline()
-{
-}
 
 bool Spline::initSpline(double ti0, double ti1, double pi0, double pi1,
                         double vi0, double vi1)


### PR DESCRIPTION
Addresses Issue 7: removes the user-declared empty destructor ~Spline() {} and lets the compiler generate the optimal default destructor automatically.