### PR TITLE
PR 6: Remove unused deque include

### DIFF
--- a/include/CHSpline/CHSpline.h
+++ b/include/CHSpline/CHSpline.h
@@ -2,7 +2,6 @@
 #define SPLINE_H
 
 #include <vector>
-#include <deque>
 #include <cmath>
 
 namespace CHSpline


### PR DESCRIPTION
Addresses Issue 8: removes the unused #include <deque> from include/CHSpline/CHSpline.h header to keep inclusions minimal and speed up compilation.