### PR TITLE
PR 8: Rename initDerivativeZero and remove CVS keywords

### DIFF
--- a/include/CHSpline/CHSpline.h
+++ b/include/CHSpline/CHSpline.h
@@ -49,7 +49,7 @@ class Spline
      \note This method requires more than 2 knots (i.e., at least one intermediary
      node). It will return false and leave the state unchanged for 2-knot splines.
   */
-  bool initDerivativezero();
+  bool initDerivativeZero();
 
   /**
      \brief Derivatives set to vector values

--- a/src/CHSpline.cpp
+++ b/src/CHSpline.cpp
@@ -3,9 +3,6 @@
  * @file  Spline.cpp
  * @brief Cubic Hermite splines implementation with first derivative end
  *conditions
- * $Date$
- *
- * $Id$
  */
 
 #include <iostream>
@@ -140,7 +137,7 @@ bool Spline::initDerivativeCatmullRom()
   return false;
 }
 
-bool Spline::initDerivativezero()
+bool Spline::initDerivativeZero()
 {
   if (t_.size() > 2)
   {

--- a/test/test_CHSpline.cpp
+++ b/test/test_CHSpline.cpp
@@ -439,7 +439,7 @@ BOOST_AUTO_TEST_CASE(Derivative_Manipulation)
   BOOST_CHECK_EQUAL(Sp.getVelocity().front(), v0);
   BOOST_CHECK_EQUAL(Sp.getVelocity().back(), v3);
 
-  BOOST_CHECK_EQUAL(Sp.initDerivativezero(), true);
+  BOOST_CHECK_EQUAL(Sp.initDerivativeZero(), true);
   BOOST_CHECK_EQUAL(Sp.getVelocity().size(), vi.size());
   BOOST_CHECK_EQUAL(Sp.getVelocity().front(), v0);
   BOOST_CHECK_EQUAL(Sp.getVelocity().back(), v3);
@@ -482,7 +482,7 @@ BOOST_AUTO_TEST_CASE(Derivative_InefectiveIfNoIntermediaryNode)
   BOOST_CHECK_EQUAL(Sp.getVelocity().front(), v0);
   BOOST_CHECK_EQUAL(Sp.getVelocity().back(), v1);
 
-  Sp.initDerivativezero();
+  Sp.initDerivativeZero();
   BOOST_CHECK_EQUAL(Sp.getVelocity().size(), vi.size());
   BOOST_CHECK_EQUAL(Sp.getVelocity().front(), v0);
   BOOST_CHECK_EQUAL(Sp.getVelocity().back(), v1);


### PR DESCRIPTION
Addresses Issue 11: renames initDerivativezero to initDerivativeZero with capital Z for consistent capitalization across the library. Also removes obsolete CVS keywords (\\$ and \\$) from src/CHSpline.cpp's header comment.