### PR TITLE
PR 11: Implement Fritsch-Carlson monotonicity-preserving interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,32 @@ Like:
 $ src/CHSplineDemo 0.0 5.0 -1.0 5.0 -1.0 0.0 100 
 ```
 
+## Monotonicity Preservation (Fritsch-Carlson)
+
+By default, Cubic Hermite Splines can overshoot or oscillate when there are sharp steps in the input points. To prevent this, the library includes an implementation of the **Fritsch-Carlson algorithm** for monotonicity-preserving cubic interpolation.
+
+If the input knot points are monotonic, this algorithm adjusts the derivatives so that the interpolated spline is guaranteed to also remain strictly monotonic, completely avoiding overshoot or undershoot.
+
+### Usage
+
+This feature is fully backward-compatible and opt-in. You can activate it by invoking the `initDerivativeMonotonicFritschCarlson()` builder after initializing your spline coordinates:
+
+```cpp
+#include "CHSpline/CHSpline.h"
+
+// Define knot points (monotonic)
+std::vector<double> ti = {0.0, 1.0, 2.0, 3.0};
+std::vector<double> pi = {0.0, 1.0, 1.1, 2.1};
+std::vector<double> vi = {0.0, 0.0}; // boundary conditions
+
+CHSpline::Spline spline;
+spline.initSpline(ti, pi, vi);
+
+// Opt-in to monotonicity-preserving derivatives
+spline.initDerivativeMonotonicFritschCarlson();
+
+// The spline is now guaranteed not to overshoot [1.0, 1.1] on the second segment
+double val = spline.evalSpline(1.5); // returns a value strictly in [1.0, 1.1]
+```
+
+

--- a/include/CHSpline/CHSpline.h
+++ b/include/CHSpline/CHSpline.h
@@ -59,6 +59,13 @@ class Spline
   bool initDerivativeZero();
 
   /**
+     \brief Monotonicity-preserving derivatives using Fritsch-Carlson algorithm
+     \note This method requires more than 2 knots. It will return false and
+     leave the state unchanged for 2-knot splines.
+  */
+  bool initDerivativeMonotonicFritschCarlson();
+
+  /**
      \brief Derivatives set to vector values
   */
   bool initDerivatives(const std::vector<double>& vi);

--- a/src/CHSpline.cpp
+++ b/src/CHSpline.cpp
@@ -172,6 +172,57 @@ bool Spline::initDerivativeZero()
   return false;
 }
 
+bool Spline::initDerivativeMonotonicFritschCarlson()
+{
+  if (t_.size() <= 2)
+  {
+    return false;
+  }
+
+  // 1. Initialize velocities using Catmull-Rom as a starting point
+  initDerivativeCatmullRom();
+
+  std::size_t n = t_.size();
+  std::vector<double> d(n - 1); // secant slopes
+
+  // 2. Compute secant slopes
+  for (std::size_t i = 0; i < n - 1; ++i)
+  {
+    d[i] = (p_[i + 1] - p_[i]) / (t_[i + 1] - t_[i]);
+  }
+
+  // 3. Apply Fritsch-Carlson monotonicity filter
+  for (std::size_t i = 0; i < n - 1; ++i)
+  {
+    double secant = d[i];
+    if (std::abs(secant) < 1e-9) // flat segment
+    {
+      v_[i] = 0.0;
+      v_[i + 1] = 0.0;
+    }
+    else
+    {
+      // Enforce sign agreement
+      if (v_[i] * secant < 0) v_[i] = 0.0;
+      if (v_[i + 1] * secant < 0) v_[i + 1] = 0.0;
+
+      double alpha = v_[i] / secant;
+      double beta = v_[i + 1] / secant;
+      double sumSquare = alpha * alpha + beta * beta;
+
+      if (sumSquare > 9.0)
+      {
+        double tau = 3.0 / std::sqrt(sumSquare);
+        v_[i] = tau * alpha * secant;
+        v_[i + 1] = tau * beta * secant;
+      }
+    }
+  }
+
+  syncKnots();
+  return true;
+}
+
 bool Spline::initDerivatives(const std::vector<double>& vi)
 {
   if (vi.size() == t_.size())

--- a/test/test_CHSpline.cpp
+++ b/test/test_CHSpline.cpp
@@ -663,4 +663,40 @@ BOOST_AUTO_TEST_CASE(EvalVectorSplineReturn_Boundaries2)
   }
 }
 
+BOOST_AUTO_TEST_CASE(Derivative_MonotonicFritschCarlson)
+{
+  Spline Sp;
+
+  // Knot points that strictly increase, but with a sharp step in the middle
+  // ti: 0.0, 1.0, 2.0, 3.0
+  // pi: 0.0, 1.0, 1.1, 2.1  (sudden flat region between 1 and 2, which causes standard Hermite splines to overshoot)
+  std::vector<double> ti = {0.0, 1.0, 2.0, 3.0};
+  std::vector<double> pi = {0.0, 1.0, 1.1, 2.1};
+  std::vector<double> vi = {0.0, 0.0}; // boundaries
+
+  Sp.initSpline(ti, pi, vi);
+
+  // Initialize with Fritsch-Carlson
+  BOOST_CHECK_EQUAL(Sp.initDerivativeMonotonicFritschCarlson(), true);
+
+  // Evaluate the spline across the flat-ish segment [1.0, 2.0]
+  // In a standard Hermite spline, this segment would overshoot (go above 1.1 or below 1.0)
+  // With Fritsch-Carlson, it must remain strictly within [1.0, 1.1]
+  for (double t = 1.0; t <= 2.0; t += 0.1)
+  {
+    double val = Sp.evalSpline(t);
+    BOOST_CHECK(val >= 1.0);
+    BOOST_CHECK(val <= 1.1);
+  }
+
+  // Also verify that the overall spline is strictly monotone (never decreases)
+  double prev = Sp.evalSpline(0.0);
+  for (double t = 0.05; t <= 3.0; t += 0.05)
+  {
+    double current = Sp.evalSpline(t);
+    BOOST_CHECK(current >= prev);
+    prev = current;
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Addresses Phase 2 PR 11: implements the Fritsch-Carlson algorithm as a new opt-in derivative builder (initDerivativeMonotonicFritschCarlson()) to prevent local extrema and curve overshoot when spline knots are monotonic. Includes comprehensive unit tests verifying monotonicity and flat-segment bounds, and fully documents the feature in the README.md.