### PR TITLE
PR 12: Modernize CMake requirements and target linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 
-# Requires at least CMake 2.8 to configure the package.
-cmake_minimum_required (VERSION 2.8) 
+# Requires at least CMake 3.5 to configure the package.
+cmake_minimum_required (VERSION 3.5) 
 
 include(cmake/base.cmake)
 include(cmake/boost.cmake)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@
 add_library(CHSpline SHARED CHSpline.cpp)
 
 add_executable (CHSplineDemo main.cpp CHSpline.cpp)
-target_link_libraries (CHSplineDemo LINK_PUBLIC CHSpline)
+target_link_libraries (CHSplineDemo PUBLIC CHSpline)
 
 install(TARGETS CHSplineDemo 
   RUNTIME DESTINATION bin


### PR DESCRIPTION
Addresses Phase 2 PR 12: upgrades minimum CMake requirement from legacy 2.8 to modern 3.5 to compile correctly on modern environments. Replaces outdated LINK_PUBLIC linkage with standard CMake PUBLIC target link specifier.